### PR TITLE
Implied Volatility Surface Visualization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,176 @@
+# Created by https://www.toptal.com/developers/gitignore/api/python
+# Edit at https://www.toptal.com/developers/gitignore?templates=python
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+### Python Patch ###
+# Poetry local configuration file - https://python-poetry.org/docs/configuration/#local-configuration
+poetry.toml
+
+# ruff
+.ruff_cache/
+
+# LSP config files
+pyrightconfig.json
+
+# End of https://www.toptal.com/developers/gitignore/api/python

--- a/OptionPricer/Option.py
+++ b/OptionPricer/Option.py
@@ -12,6 +12,7 @@ class Option(abc.ABC):
     volatility: float # constant volatility
     maturity: datetime # expected format: "%m/%d/%Y"
     strike: float
+    dividend: float # constant dividend
 
     def __post_init__(self):
         """
@@ -20,6 +21,7 @@ class Option(abc.ABC):
         """
         assert self.volatility >= 0, "Volatility must be positive"
         assert self.underlying_price >= 0, "Underlying price must be positive"
+        assert self.dividend >= 0, "Dividend must be positive"
 
         if type(self.maturity) == str:
             self.maturity = datetime.strptime(self.maturity, '%m/%d/%Y')

--- a/OptionPricer/Option.py
+++ b/OptionPricer/Option.py
@@ -1,0 +1,27 @@
+import abc
+from dataclasses import dataclass
+from datetime import datetime
+
+@dataclass
+class Option(abc.ABC):
+    """
+    Abstract class to represent an option
+    """
+    S: float # underlying spot price
+    r: float # constant risk-free rate
+    sigma: float # constant volatility
+    T: datetime # maturity
+    K: float # strike
+
+
+@dataclass
+class Call(Option):
+    """
+    Class to represent a call option
+    """
+
+@dataclass
+class Put(Option):
+    """
+    Class to represent a put option
+    """

--- a/OptionPricer/Option.py
+++ b/OptionPricer/Option.py
@@ -7,20 +7,31 @@ class Option(abc.ABC):
     """
     Abstract class to represent an option
     """
-    S: float # underlying spot price
-    r: float # constant risk-free rate
-    sigma: float # constant volatility
-    T: datetime # maturity
-    K: float # strike
+    underlying_price: float # underlying spot price
+    rate: float # constant risk-free rate
+    volatility: float # constant volatility
+    maturity: datetime # expected format: "%m/%d/%Y"
+    strike: float
+
+    def __post_init__(self):
+        """
+        Checks whether entered parameters meet Black-Scholes hypothesis
+        and transforms maturity into datetime if needed
+        """
+        assert self.volatility >= 0, "Volatility must be positive"
+        assert self.underlying_price >= 0, "Underlying price must be positive"
+
+        if type(self.maturity) == str:
+            self.maturity = datetime.strptime(self.maturity, '%m/%d/%Y')
+            assert self.maturity > datetime.today(), "Maturity date must be greater than calculation date"
 
 
-@dataclass
+
 class Call(Option):
     """
     Class to represent a call option
     """
 
-@dataclass
 class Put(Option):
     """
     Class to represent a put option

--- a/OptionPricer/Pricers/BlackScholesPricer.py
+++ b/OptionPricer/Pricers/BlackScholesPricer.py
@@ -1,0 +1,43 @@
+from typing import Union
+from numpy import sqrt, exp, log
+from Option import Call, Put
+from scipy.stats import norm
+from datetime import datetime
+
+
+
+CONVENTION_YEAR_FRACTION = 365
+        
+
+
+class BlackScholesPricer:
+    """
+    Calculator of the today price of an european option based on the Black-Scholes model
+    """
+
+    def __init__(self, instrument: Union[Call, Put]):
+        self.instrument = instrument
+        calculation_date = datetime.today()
+
+        assert isinstance(instrument, Call) or isinstance(instrument, Put), f"{self.instrument} is not recognized as a Call or Put option"
+        assert instrument.maturity > calculation_date, "Maturity date must be greater than calculation date"
+
+        self.S = instrument.underlying_price
+        self.K = instrument.strike
+        self.r = instrument.rate
+        self.sigma = instrument.volatility
+        self.T = (instrument.maturity - calculation_date).days / CONVENTION_YEAR_FRACTION # time to maturity as a year fraction
+        self.d1 = (log(self.S/self.K) + self.r*self.T + 0.5*self.T*self.sigma**2) / (self.sigma*sqrt(self.T))
+        self.d2 = self.d1 - self.sigma*sqrt(self.T)
+
+
+    def calculate(self) -> float:
+        """
+        Calculate the price of the option
+        """
+        
+        if isinstance(self.instrument, Call):
+            return self.S*norm.cdf(self.d1) - self.K * exp(-self.r*self.T) * norm.cdf(self.d2)
+
+        elif isinstance(self.instrument, Put):
+            return -self.S*norm.cdf(-self.d1) + self.K * exp(-self.r*self.T) * norm.cdf(-self.d2)

--- a/OptionPricer/Pricers/BlackScholesPricer.py
+++ b/OptionPricer/Pricers/BlackScholesPricer.py
@@ -25,6 +25,7 @@ class BlackScholesPricer:
         self.S = instrument.underlying_price
         self.K = instrument.strike
         self.r = instrument.rate
+        self.q = instrument.dividend
         self.sigma = instrument.volatility
         self.T = (instrument.maturity - calculation_date).days / CONVENTION_YEAR_FRACTION # time to maturity as a year fraction
         self.d1 = (log(self.S/self.K) + self.r*self.T + 0.5*self.T*self.sigma**2) / (self.sigma*sqrt(self.T))
@@ -37,7 +38,7 @@ class BlackScholesPricer:
         """
         
         if isinstance(self.instrument, Call):
-            return self.S*norm.cdf(self.d1) - self.K * exp(-self.r*self.T) * norm.cdf(self.d2)
+            return self.S * exp(-self.q*self.T) * norm.cdf(self.d1) - self.K * exp(-self.r*self.T) * norm.cdf(self.d2)
 
         elif isinstance(self.instrument, Put):
-            return -self.S*norm.cdf(-self.d1) + self.K * exp(-self.r*self.T) * norm.cdf(-self.d2)
+            return -self.S * exp(-self.q*self.T) * norm.cdf(-self.d1) + self.K * exp(-self.r*self.T) * norm.cdf(-self.d2)

--- a/OptionPricer/Pricers/BlackScholesPricer.py
+++ b/OptionPricer/Pricers/BlackScholesPricer.py
@@ -1,4 +1,4 @@
-from numpy import exp
+from numpy import exp, log, sqrt
 from Option import Call, Put
 from scipy.stats import norm
 from Pricers.Pricer import Pricer
@@ -16,9 +16,11 @@ class BlackScholesPricer(Pricer):
         """
         Calculate the price of the option
         """
+        d1 = (log(self.S/self.K) + self.r*self.T + 0.5*self.T*self.sigma**2) / (self.sigma*sqrt(self.T))
+        d2 = d1 - self.sigma*sqrt(self.T)
         
         if isinstance(self.instrument, Call):
-            return self.S * exp(-self.q*self.T) * norm.cdf(self.d1) - self.K * exp(-self.r*self.T) * norm.cdf(self.d2)
+            return self.S * exp(-self.q*self.T) * norm.cdf(d1) - self.K * exp(-self.r*self.T) * norm.cdf(d2)
 
         elif isinstance(self.instrument, Put):
-            return -self.S * exp(-self.q*self.T) * norm.cdf(-self.d1) + self.K * exp(-self.r*self.T) * norm.cdf(-self.d2)
+            return -self.S * exp(-self.q*self.T) * norm.cdf(-d1) + self.K * exp(-self.r*self.T) * norm.cdf(-d2)

--- a/OptionPricer/Pricers/BlackScholesPricer.py
+++ b/OptionPricer/Pricers/BlackScholesPricer.py
@@ -1,36 +1,16 @@
-from typing import Union
-from numpy import sqrt, exp, log
+from numpy import exp
 from Option import Call, Put
 from scipy.stats import norm
-from datetime import datetime
+from Pricers.Pricer import Pricer
 
 
 
-CONVENTION_YEAR_FRACTION = 365
-        
 
 
-class BlackScholesPricer:
+class BlackScholesPricer(Pricer):
     """
     Calculator of the today price of an european option based on the Black-Scholes model
     """
-
-    def __init__(self, instrument: Union[Call, Put]):
-        self.instrument = instrument
-        calculation_date = datetime.today()
-
-        assert isinstance(instrument, Call) or isinstance(instrument, Put), f"{self.instrument} is not recognized as a Call or Put option"
-        assert instrument.maturity > calculation_date, "Maturity date must be greater than calculation date"
-
-        self.S = instrument.underlying_price
-        self.K = instrument.strike
-        self.r = instrument.rate
-        self.q = instrument.dividend
-        self.sigma = instrument.volatility
-        self.T = (instrument.maturity - calculation_date).days / CONVENTION_YEAR_FRACTION # time to maturity as a year fraction
-        self.d1 = (log(self.S/self.K) + self.r*self.T + 0.5*self.T*self.sigma**2) / (self.sigma*sqrt(self.T))
-        self.d2 = self.d1 - self.sigma*sqrt(self.T)
-
 
     def calculate(self) -> float:
         """

--- a/OptionPricer/Pricers/MonteCarloPricer.py
+++ b/OptionPricer/Pricers/MonteCarloPricer.py
@@ -1,0 +1,27 @@
+from Option import Call, Put
+import numpy as np
+from Pricers.Pricer import Pricer
+
+
+
+
+class MonteCarloPricer(Pricer):
+    """
+    Calculator of the today price of an european option with Monte Carlo
+    """
+
+    def calculate(self, nb_samples: int) -> float:
+        """
+        Calculate the price of the option with simple Monte Carlo
+        """
+        
+        W_T = np.sqrt(self.T) * np.random.normal(size=nb_samples) # W_T \sim \sqrt{T}\mathcal{N}(0,1)
+        S_T = self.S * np.exp( (self.r - self.q - 0.5 * self.sigma**2) * self.T + self.sigma * W_T) # vector of size nb_samples. Solution of the Black-Scholes EDS
+
+        if isinstance(self.instrument, Call):
+            payoff = np.maximum( S_T - self.K, 0) # np.maximum to compute the max for each element of the array. np.max computes the max of the array
+        
+        elif isinstance(self.instrument, Put):
+            payoff = np.maximum( self.K - S_T, 0)
+        
+        return np.mean(payoff * np.exp(-self.r * self.T))

--- a/OptionPricer/Pricers/MonteCarloPricer.py
+++ b/OptionPricer/Pricers/MonteCarloPricer.py
@@ -39,3 +39,18 @@ class MonteCarloPricer(Pricer):
         S_T = self.S * np.exp( (self.r - self.q - 0.5 * self.sigma**2) * self.T + self.sigma * W_T) # vector of size nb_samples. Solution of the Black-Scholes EDS
         
         return np.mean(self.payoff(S_T) * np.exp(-self.r * self.T))
+
+
+    def calculate_antithetic(self, nb_samples: int) -> float:
+        """
+        Calculate the price of the option with antithetic variables
+        """
+        
+        W_T = np.sqrt(self.T) * np.random.normal(size=nb_samples)
+        drift = (self.r - self.q - 0.5 * self.sigma**2) * self.T
+        S_T1 = self.S * np.exp( drift + self.sigma * W_T)
+        S_T2 = self.S * np.exp( drift + self.sigma * -W_T) # antithetic of S_T1
+
+        payoff = ( self.payoff(S_T1) + self.payoff(S_T2) )/2
+
+        return np.mean(payoff * np.exp(-self.r * self.T))

--- a/OptionPricer/Pricers/MonteCarloPricer.py
+++ b/OptionPricer/Pricers/MonteCarloPricer.py
@@ -2,6 +2,8 @@ from Option import Call, Put
 import numpy as np
 from Pricers.Pricer import Pricer
 
+from scipy.stats import norm
+from scipy.stats.qmc import Sobol
 
 
 
@@ -17,11 +19,5 @@ class MonteCarloPricer(Pricer):
         
         W_T = np.sqrt(self.T) * np.random.normal(size=nb_samples) # W_T \sim \sqrt{T}\mathcal{N}(0,1)
         S_T = self.S * np.exp( (self.r - self.q - 0.5 * self.sigma**2) * self.T + self.sigma * W_T) # vector of size nb_samples. Solution of the Black-Scholes EDS
-
-        if isinstance(self.instrument, Call):
-            payoff = np.maximum( S_T - self.K, 0) # np.maximum to compute the max for each element of the array. np.max computes the max of the array
         
-        elif isinstance(self.instrument, Put):
-            payoff = np.maximum( self.K - S_T, 0)
-        
-        return np.mean(payoff * np.exp(-self.r * self.T))
+        return np.mean(self.payoff(S_T) * np.exp(-self.r * self.T))

--- a/OptionPricer/Pricers/MonteCarloPricer.py
+++ b/OptionPricer/Pricers/MonteCarloPricer.py
@@ -21,3 +21,21 @@ class MonteCarloPricer(Pricer):
         S_T = self.S * np.exp( (self.r - self.q - 0.5 * self.sigma**2) * self.T + self.sigma * W_T) # vector of size nb_samples. Solution of the Black-Scholes EDS
         
         return np.mean(self.payoff(S_T) * np.exp(-self.r * self.T))
+
+
+    def calculate_qmc(self, nb_samples: int) -> float:
+        """
+        Calculate the price of the option with Quasi-Monte Carlo with a Sobol sequence
+        """
+
+        sampler = Sobol(d=1, scramble=True) # d=1 cause we need 1 dimension. Scramble=True to introduce randomness into the sequence without destroying the low-discrepancy
+        U = sampler.random(nb_samples).flatten() # generate the sequence, \sim U([0, 1]). Better uniformity if nb_samples is a power of 2
+
+        G = norm.ppf(U) # map U([0,1]) samples to N(0,1) via the inverse of the repartition function
+
+        W_T = np.sqrt(self.T) * G
+        
+        W_T = np.sqrt(self.T) * np.random.normal(size=nb_samples) # W_T \sim \sqrt{T}\mathcal{N}(0,1)
+        S_T = self.S * np.exp( (self.r - self.q - 0.5 * self.sigma**2) * self.T + self.sigma * W_T) # vector of size nb_samples. Solution of the Black-Scholes EDS
+        
+        return np.mean(self.payoff(S_T) * np.exp(-self.r * self.T))

--- a/OptionPricer/Pricers/MonteCarloPricer.py
+++ b/OptionPricer/Pricers/MonteCarloPricer.py
@@ -90,3 +90,28 @@ class MonteCarloPricer(Pricer):
             count_draws += len(G)
 
         return (sum_payoff / nb_samples) * np.exp(-self.r * self.T)
+
+
+    def benchmark(self, nb_samples: int):
+        """
+        Time the execution of Monte Carlo pricing methods
+        """
+
+        results = {}
+        methods = ["calculate", "calculate_antithetic", "calculate_lazy", "calculate_qmc"]
+
+        for method in methods:
+            durations = []
+            prices = []
+            for _ in range(1000):
+                start = time.time()
+                price = getattr(self, method)(nb_samples)
+                prices.append(price)
+                durations.append(time.time() - start)
+
+            results[method] = {
+                "time": round(float(np.mean(durations)), 6),
+                "price": round(float(np.mean(prices)), 6)
+            }
+
+        return results

--- a/OptionPricer/Pricers/Pricer.py
+++ b/OptionPricer/Pricers/Pricer.py
@@ -1,5 +1,5 @@
 from typing import Union
-from numpy import sqrt, log
+import numpy as np
 from Option import Call, Put
 from datetime import datetime
 import abc
@@ -28,8 +28,13 @@ class Pricer(abc.ABC):
         self.q = instrument.dividend
         self.sigma = instrument.volatility
         self.T = (instrument.maturity - calculation_date).days / CONVENTION_YEAR_FRACTION # time to maturity as a year fraction
-        self.d1 = (log(self.S/self.K) + self.r*self.T + 0.5*self.T*self.sigma**2) / (self.sigma*sqrt(self.T))
-        self.d2 = self.d1 - self.sigma*sqrt(self.T)
+        self.d1 = (np.log(self.S/self.K) + self.r*self.T + 0.5*self.T*self.sigma**2) / (self.sigma*np.sqrt(self.T))
+        self.d2 = self.d1 - self.sigma*np.sqrt(self.T)
+
+        if isinstance(instrument, Call):
+            self.payoff = lambda S_T: np.maximum(S_T - self.K, 0)
+        elif isinstance(instrument, Put):
+            self.payoff = lambda S_T: np.maximum(self.K - S_T, 0)
 
     @abc.abstractmethod
     def calculate(self) -> float:

--- a/OptionPricer/Pricers/Pricer.py
+++ b/OptionPricer/Pricers/Pricer.py
@@ -28,8 +28,6 @@ class Pricer(abc.ABC):
         self.q = instrument.dividend
         self.sigma = instrument.volatility
         self.T = (instrument.maturity - calculation_date).days / CONVENTION_YEAR_FRACTION # time to maturity as a year fraction
-        self.d1 = (np.log(self.S/self.K) + self.r*self.T + 0.5*self.T*self.sigma**2) / (self.sigma*np.sqrt(self.T))
-        self.d2 = self.d1 - self.sigma*np.sqrt(self.T)
 
         if isinstance(instrument, Call):
             self.payoff = lambda S_T: np.maximum(S_T - self.K, 0)

--- a/OptionPricer/Pricers/Pricer.py
+++ b/OptionPricer/Pricers/Pricer.py
@@ -1,0 +1,38 @@
+from typing import Union
+from numpy import sqrt, log
+from Option import Call, Put
+from datetime import datetime
+import abc
+
+
+
+CONVENTION_YEAR_FRACTION = 365
+        
+
+
+class Pricer(abc.ABC):
+    """
+    Calculator of the today price of an european option based on the Black-Scholes model
+    """
+
+    def __init__(self, instrument: Union[Call, Put]):
+        self.instrument = instrument
+        calculation_date = datetime.today()
+
+        assert isinstance(instrument, Call) or isinstance(instrument, Put), f"{self.instrument} is not recognized as a Call or Put option"
+        assert instrument.maturity > calculation_date, "Maturity date must be greater than calculation date"
+
+        self.S = instrument.underlying_price
+        self.K = instrument.strike
+        self.r = instrument.rate
+        self.q = instrument.dividend
+        self.sigma = instrument.volatility
+        self.T = (instrument.maturity - calculation_date).days / CONVENTION_YEAR_FRACTION # time to maturity as a year fraction
+        self.d1 = (log(self.S/self.K) + self.r*self.T + 0.5*self.T*self.sigma**2) / (self.sigma*sqrt(self.T))
+        self.d2 = self.d1 - self.sigma*sqrt(self.T)
+
+    @abc.abstractmethod
+    def calculate(self) -> float:
+        """
+        Calculate the price of the option
+        """

--- a/OptionPricer/VolatilitySurface.py
+++ b/OptionPricer/VolatilitySurface.py
@@ -2,6 +2,7 @@ import yfinance as yf
 import numpy as np
 import pandas as pd
 from datetime import datetime
+import plotly.graph_objects as go
 
 
 def build_iv_surface(ticker: yf.ticker.Ticker):
@@ -37,3 +38,34 @@ def build_iv_surface(ticker: yf.ticker.Ticker):
 
     return pd.DataFrame(iv_surface_data, columns=["Strike", "Maturity", "IV"])
 
+
+def plot_iv_surface(iv_df: pd.DataFrame):
+    """
+    Builds implied volatility surface from a  plots it as a 3D surface using Plotly
+    Parameters:
+    - iv_df: pd.DataFrame of the volatility surface to plot
+    """
+    
+    assert not iv_df.empty, "No implied volatility data found. Cannot plot"
+
+    df_pivot = iv_df.pivot(index="Strike", columns="Maturity", values="IV") # pivot the DataFrame to extract fields domains
+
+    fig = go.Figure(data=[
+        go.Surface(
+            x = df_pivot.index.values, # strike
+            y = df_pivot.columns.values, # maturity in years
+            z = df_pivot.values # implied vol
+        )
+    ])
+
+    fig.update_layout(
+        title="Implied Volatility Surface",
+        scene=dict(
+            xaxis_title="Strike",
+            yaxis_title="Time to Maturity (Years)",
+            zaxis_title="Implied Volatility"
+        ),
+        autosize=True
+    )
+
+    fig.show()

--- a/OptionPricer/VolatilitySurface.py
+++ b/OptionPricer/VolatilitySurface.py
@@ -1,0 +1,39 @@
+import yfinance as yf
+import numpy as np
+import pandas as pd
+from datetime import datetime
+
+
+def build_iv_surface(ticker: yf.ticker.Ticker):
+    """
+    Builds an implied volatility surface from an underlying
+    
+    Parameters:
+    - ticker: yfinance Ticker object, represents a stock
+    Returns:
+    - pd.DataFrame with columns: Strike, Maturity, IV
+    """
+    iv_surface_data = []
+    now = datetime.now()
+    ticker._download_options() # important to get expiration dates from ticker._expiratoins
+    expirations = ticker._expirations # dict: {'2025-03-28': epoch_time, ...}
+
+    for expiry_str in expirations.keys():
+        try:
+            df = ticker.option_chain(expiry_str).puts # strikes and vols for calls are about the same
+            maturity_date = datetime.strptime(expiry_str, "%Y-%m-%d")
+            T = (maturity_date - now).days / 365.0
+
+            strikes = df["strike"]
+            vols = df["impliedVolatility"]
+
+            for K, iv in zip(strikes, vols):
+                if not np.isnan(iv):
+                    iv_surface_data.append((K, T, iv))
+
+        except Exception as e:
+            print(f"Error processing {expiry_str}: {e}")
+            continue # go to next iteration
+
+    return pd.DataFrame(iv_surface_data, columns=["Strike", "Maturity", "IV"])
+

--- a/OptionPricer/VolatilitySurface.py
+++ b/OptionPricer/VolatilitySurface.py
@@ -5,67 +5,80 @@ from datetime import datetime
 import plotly.graph_objects as go
 
 
-def build_iv_surface(ticker: yf.ticker.Ticker):
-    """
-    Builds an implied volatility surface from an underlying
-    
-    Parameters:
-    - ticker: yfinance Ticker object, represents a stock
-    Returns:
-    - pd.DataFrame with columns: Strike, Maturity, IV
-    """
-    iv_surface_data = []
-    now = datetime.now()
-    ticker._download_options() # important to get expiration dates from ticker._expiratoins
-    expirations = ticker._expirations # dict: {'2025-03-28': epoch_time, ...}
+class VolatilitySurface:
 
-    for expiry_str in expirations.keys():
-        try:
-            df = ticker.option_chain(expiry_str).puts # strikes and vols for calls are about the same
-            maturity_date = datetime.strptime(expiry_str, "%Y-%m-%d")
-            T = (maturity_date - now).days / 365.0
+    def __init__(self, ticker_name: str):
+        """
+        Initializes the IVSurface object with a yfinance ticker
 
-            strikes = df["strike"]
-            vols = df["impliedVolatility"]
+        Parameters:
+        - ticker_name: Ticker name of a stock
+        """
+        self.ticker = yf.Ticker(ticker_name)
 
-            for K, iv in zip(strikes, vols):
-                if not np.isnan(iv):
-                    iv_surface_data.append((K, T, iv))
+    def _build_iv_surface(self):
+        """
+        Builds an implied volatility surface from an underlying
+        
+        Parameters:
+        - ticker: yfinance Ticker object, represents a stock
+        Returns:
+        - pd.DataFrame with columns: Strike, Maturity, IV
+        """
+        iv_surface_data = []
+        now = datetime.now()
+        self.ticker._download_options() # important to get expiration dates from ticker._expiratoins
+        expirations = self.ticker._expirations # dict: {'2025-03-28': epoch_time, ...}
 
-        except Exception as e:
-            print(f"Error processing {expiry_str}: {e}")
-            continue # go to next iteration
+        for expiry_str in expirations.keys():
+            try:
+                df = self.ticker.option_chain(expiry_str).puts # strikes and vols for calls are about the same
+                maturity_date = datetime.strptime(expiry_str, "%Y-%m-%d")
+                T = (maturity_date - now).days / 365.0
 
-    return pd.DataFrame(iv_surface_data, columns=["Strike", "Maturity", "IV"])
+                strikes = df["strike"]
+                vols = df["impliedVolatility"]
+
+                for K, iv in zip(strikes, vols):
+                    if not np.isnan(iv):
+                        iv_surface_data.append((K, T, iv))
+
+            except Exception as e:
+                print(f"Error processing {expiry_str}: {e}")
+                continue # go to next iteration
+
+        return pd.DataFrame(iv_surface_data, columns=["Strike", "Maturity", "IV"])
 
 
-def plot_iv_surface(iv_df: pd.DataFrame):
-    """
-    Builds implied volatility surface from a  plots it as a 3D surface using Plotly
-    Parameters:
-    - iv_df: pd.DataFrame of the volatility surface to plot
-    """
-    
-    assert not iv_df.empty, "No implied volatility data found. Cannot plot"
+    def plot_iv_surface(self):
+        """
+        Builds implied volatility surface from a  plots it as a 3D surface using Plotly
+        Parameters:
+        - iv_df: pd.DataFrame of the volatility surface to plot
+        """
 
-    df_pivot = iv_df.pivot(index="Strike", columns="Maturity", values="IV") # pivot the DataFrame to extract fields domains
+        iv_df = self._build_iv_surface()
+        
+        assert not iv_df.empty, "No implied volatility data found. Cannot plot"
 
-    fig = go.Figure(data=[
-        go.Surface(
-            x = df_pivot.index.values, # strike
-            y = df_pivot.columns.values, # maturity in years
-            z = df_pivot.values # implied vol
+        df_pivot = iv_df.pivot(index="Strike", columns="Maturity", values="IV") # pivot the DataFrame to extract fields domains
+
+        fig = go.Figure(data=[
+            go.Surface(
+                x = df_pivot.index.values, # strike
+                y = df_pivot.columns.values, # maturity in years
+                z = df_pivot.values # implied vol
+            )
+        ])
+
+        fig.update_layout(
+            title="Implied Volatility Surface",
+            scene=dict(
+                xaxis_title="Strike",
+                yaxis_title="Time to Maturity (Years)",
+                zaxis_title="Implied Volatility"
+            ),
+            autosize=True
         )
-    ])
 
-    fig.update_layout(
-        title="Implied Volatility Surface",
-        scene=dict(
-            xaxis_title="Strike",
-            yaxis_title="Time to Maturity (Years)",
-            zaxis_title="Implied Volatility"
-        ),
-        autosize=True
-    )
-
-    fig.show()
+        fig.show()

--- a/OptionPricer/main.py
+++ b/OptionPricer/main.py
@@ -22,3 +22,5 @@ if __name__ == "__main__":
     print("Monte Carlo calculate_qmc", pricer_monte_carlo.calculate_qmc(nb_samples))
     print("Monte Carlo calculate_antithetc", pricer_monte_carlo.calculate_antithetic(nb_samples))
     print("Monte Carlo calculate_lazy", pricer_monte_carlo.calculate_lazy(nb_samples))
+
+    print(pricer_monte_carlo.benchmark(10000))

--- a/OptionPricer/main.py
+++ b/OptionPricer/main.py
@@ -1,4 +1,5 @@
 from Pricers.BlackScholesPricer import BlackScholesPricer
+from Pricers.MonteCarloPricer import MonteCarloPricer
 from Option import Call, Put
 
 
@@ -12,6 +13,9 @@ if __name__ == "__main__":
                     volatility= 0.2,
                     dividend= 0.04)
 
-    pricer = BlackScholesPricer(instrument)
-    price = pricer.calculate()
-    print(price)
+    pricer_black_scholes = BlackScholesPricer(instrument)
+    print("Black-Scholes: ", pricer_black_scholes.calculate())
+
+    pricer_monte_carlo = MonteCarloPricer(instrument)
+    nb_samples = 100_000
+    print("Monte Carlo", pricer_monte_carlo.calculate(nb_samples))

--- a/OptionPricer/main.py
+++ b/OptionPricer/main.py
@@ -17,5 +17,6 @@ if __name__ == "__main__":
     print("Black-Scholes: ", pricer_black_scholes.calculate())
 
     pricer_monte_carlo = MonteCarloPricer(instrument)
-    nb_samples = 100_000
-    print("Monte Carlo", pricer_monte_carlo.calculate(nb_samples))
+    nb_samples = 2**18 # power of 2 for Sobol sequence in qmc
+    print("Monte Carlo calculate", pricer_monte_carlo.calculate(nb_samples))
+    print("Monte Carlo calculate_qmc", pricer_monte_carlo.calculate_qmc(nb_samples))

--- a/OptionPricer/main.py
+++ b/OptionPricer/main.py
@@ -20,3 +20,4 @@ if __name__ == "__main__":
     nb_samples = 2**18 # power of 2 for Sobol sequence in qmc
     print("Monte Carlo calculate", pricer_monte_carlo.calculate(nb_samples))
     print("Monte Carlo calculate_qmc", pricer_monte_carlo.calculate_qmc(nb_samples))
+    print("Monte Carlo calculate_antithetc", pricer_monte_carlo.calculate_antithetic(nb_samples))

--- a/OptionPricer/main.py
+++ b/OptionPricer/main.py
@@ -1,7 +1,7 @@
 from Pricers.BlackScholesPricer import BlackScholesPricer
 from Pricers.MonteCarloPricer import MonteCarloPricer
 from Option import Call, Put
-from VolatilitySurface import build_iv_surface
+from VolatilitySurface import build_iv_surface, plot_iv_surface
 import yfinance as yf
 
 
@@ -29,4 +29,4 @@ if __name__ == "__main__":
 
     ticker = yf.Ticker("AAPL") # Apple stock
     iv_df = build_iv_surface(ticker)
-    print(iv_df)
+    plot_iv_surface(iv_df)

--- a/OptionPricer/main.py
+++ b/OptionPricer/main.py
@@ -21,3 +21,4 @@ if __name__ == "__main__":
     print("Monte Carlo calculate", pricer_monte_carlo.calculate(nb_samples))
     print("Monte Carlo calculate_qmc", pricer_monte_carlo.calculate_qmc(nb_samples))
     print("Monte Carlo calculate_antithetc", pricer_monte_carlo.calculate_antithetic(nb_samples))
+    print("Monte Carlo calculate_lazy", pricer_monte_carlo.calculate_lazy(nb_samples))

--- a/OptionPricer/main.py
+++ b/OptionPricer/main.py
@@ -1,8 +1,7 @@
 from Pricers.BlackScholesPricer import BlackScholesPricer
 from Pricers.MonteCarloPricer import MonteCarloPricer
 from Option import Call, Put
-from VolatilitySurface import build_iv_surface, plot_iv_surface
-import yfinance as yf
+from VolatilitySurface import VolatilitySurface
 
 
 
@@ -27,6 +26,4 @@ if __name__ == "__main__":
 
     # print(pricer_monte_carlo.benchmark(10000))
 
-    ticker = yf.Ticker("AAPL") # Apple stock
-    iv_df = build_iv_surface(ticker)
-    plot_iv_surface(iv_df)
+    VolatilitySurface("AAPL").plot_iv_surface()

--- a/OptionPricer/main.py
+++ b/OptionPricer/main.py
@@ -1,0 +1,16 @@
+from Pricers.BlackScholesPricer import BlackScholesPricer
+from Option import Call, Put
+
+
+
+if __name__ == "__main__":
+
+    instrument = Call(maturity="04/22/2025",
+                    rate= 0.1,
+                    strike= 100,
+                    underlying_price= 150,
+                    volatility= 0.2)
+
+    pricer = BlackScholesPricer(instrument)
+    price = pricer.calculate()
+    print(price)

--- a/OptionPricer/main.py
+++ b/OptionPricer/main.py
@@ -9,7 +9,8 @@ if __name__ == "__main__":
                     rate= 0.1,
                     strike= 100,
                     underlying_price= 150,
-                    volatility= 0.2)
+                    volatility= 0.2,
+                    dividend= 0.04)
 
     pricer = BlackScholesPricer(instrument)
     price = pricer.calculate()

--- a/OptionPricer/main.py
+++ b/OptionPricer/main.py
@@ -1,6 +1,8 @@
 from Pricers.BlackScholesPricer import BlackScholesPricer
 from Pricers.MonteCarloPricer import MonteCarloPricer
 from Option import Call, Put
+from VolatilitySurface import build_iv_surface
+import yfinance as yf
 
 
 
@@ -13,14 +15,18 @@ if __name__ == "__main__":
                     volatility= 0.2,
                     dividend= 0.04)
 
-    pricer_black_scholes = BlackScholesPricer(instrument)
-    print("Black-Scholes: ", pricer_black_scholes.calculate())
+    # pricer_black_scholes = BlackScholesPricer(instrument)
+    # print("Black-Scholes: ", pricer_black_scholes.calculate())
 
-    pricer_monte_carlo = MonteCarloPricer(instrument)
-    nb_samples = 2**18 # power of 2 for Sobol sequence in qmc
-    print("Monte Carlo calculate", pricer_monte_carlo.calculate(nb_samples))
-    print("Monte Carlo calculate_qmc", pricer_monte_carlo.calculate_qmc(nb_samples))
-    print("Monte Carlo calculate_antithetc", pricer_monte_carlo.calculate_antithetic(nb_samples))
-    print("Monte Carlo calculate_lazy", pricer_monte_carlo.calculate_lazy(nb_samples))
+    # pricer_monte_carlo = MonteCarloPricer(instrument)
+    # nb_samples = 2**18 # power of 2 for Sobol sequence in qmc
+    # print("Monte Carlo calculate", pricer_monte_carlo.calculate(nb_samples))
+    # print("Monte Carlo calculate_qmc", pricer_monte_carlo.calculate_qmc(nb_samples))
+    # print("Monte Carlo calculate_antithetc", pricer_monte_carlo.calculate_antithetic(nb_samples))
+    # print("Monte Carlo calculate_lazy", pricer_monte_carlo.calculate_lazy(nb_samples))
 
-    print(pricer_monte_carlo.benchmark(10000))
+    # print(pricer_monte_carlo.benchmark(10000))
+
+    ticker = yf.Ticker("AAPL") # Apple stock
+    iv_df = build_iv_surface(ticker)
+    print(iv_df)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 numpy==2.2.4
 scipy==1.15.2
+yfinance==0.2.55
+plotly==6.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+numpy==2.2.4
+scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 numpy==2.2.4
-scipy
+scipy==1.15.2


### PR DESCRIPTION

### Summary

VolatilitySurface` class that constructs and visualizes the **Implied Volatility (IV) Surface** of a given stock using data from **Yahoo Finance** via the `yfinance` library.

### Key Additions

- **`VolatilitySurface` class**:
  - Initialized with a stock ticker (e.g., `"AAPL"`, `"MSFT"`).
  - Retrieves all available option chains and builds an implied volatility surface from put options.
  - Uses the maturity (in years) and strike as dimensions, with implied volatility as the value.

### Methods

- `_build_iv_surface(self) -> pd.DataFrame`:
  - Downloads for all available expirations (maturities)
  - Constructs a DataFrame with columns: `["Strike", "Maturity", "IV"]`.

- `plot_iv_surface(self)`:
  - Builds the IV surface by calling `_build_iv_surface(self) ` and plots it as a 3D surface using **Plotly**.
  - The surface shows how implied volatility varies across strike prices and time to maturity.

### Example Usage

```python
from VolatilitySurface import VolatilitySurface

vs = VolatilitySurface("AAPL")
vs.plot_iv_surface()
```

### Future Enhancements
- **Interpolation**: the volatility surface misses data points